### PR TITLE
Minor update to ROS 2 Bouncy

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@ find_package(std_msgs REQUIRED)
 find_package(builtin_interfaces REQUIRED)
 find_package(rosidl_default_generators REQUIRED)
 
-set_directory_properties(PROPERTIES COMPILE_OPTIONS "-std=c++11")
+set_directory_properties(PROPERTIES COMPILE_OPTIONS "-std=c++14")
 
 # Dynamic reconfigure support
 #generate_dynamic_reconfigure_options(cfg/URG.cfg)


### PR DESCRIPTION
Hi, just set the compiler to c++14 to use with ROS 2 Bouncy.